### PR TITLE
Map user-configured oauth userinfo headers

### DIFF
--- a/src/headers.js
+++ b/src/headers.js
@@ -1,0 +1,54 @@
+const jq = require("node-jq");
+
+const JQ_OPTIONS = {
+  input: "json",
+  output: "json",
+};
+
+/**
+ * Populates response headers using the given JQ config and data payload.
+ *
+ * Config can either be an object mapping of headerName --> jq query for that
+ * value. Alternatively it can be a string representation of a jq query that
+ * returns an object mapping of headerName --> value.
+ */
+const populateResponseHeader = async (res, config, data, logger) => {
+  if (!config) {
+    return;
+  }
+
+  // When the config is a string we expect it to be a jq expression that returns
+  // an object of `headerName` --> `value`.
+  if (typeof config === "string") {
+    const headers = await jq.run(config, data, JQ_OPTIONS);
+    if (typeof headers !== "object" || headers instanceof Array) {
+      logger.warn(
+        `Invalid jq response when processing configured headers. Skipping.`);
+        return;
+    }
+    for (let [headerName, value] of Object.entries(headers)) {
+      setHeader(res, headerName, value);
+    }
+  } else {
+    for (let [headerName, query] of Object.entries(config)) {
+      const value = await jq.run(query, data, JQ_OPTIONS);
+      setHeader(res, headerName, value);
+    }
+  }
+};
+
+/**
+ * Sets the given header on the response object.
+ *
+ * If the value is not a string then the value will be `JSON.stringify`'d.
+ */
+const setHeader = (res, headerName, value) => {
+  if (typeof value !== "string") {
+    value = JSON.stringify(value);
+  }
+  res.setHeader(headerName, value);
+};
+
+module.exports = {
+  populateResponseHeader,
+};

--- a/src/plugin/oauth/index.js
+++ b/src/plugin/oauth/index.js
@@ -766,6 +766,14 @@ class BaseOauthPlugin extends BasePlugin {
 
   prepare_token_headers(res, sessionData) {
     const plugin = this;
+
+    // Set user-defined headers first so that they don't overwrite others.
+    if (plugin.config.headers && sessionData.userinfo.data) {
+      for (let [header, field] of Object.entries(plugin.config.headers)) {
+        res.setHeader(`X-${header}`, sessionData.userinfo.data[field]);
+      }
+    }
+
     if (sessionData.tokenSet.id_token) {
       res.setHeader("X-Id-Token", sessionData.tokenSet.id_token);
     }


### PR DESCRIPTION
A new `headers` config option has been added which is a map of
`header name` --> `user-info` attribute. These headers will be set
first so they cannot overwrite default headers set by eas. In
addition the headers will always be prefixed with X-.

An example config might be:

```
{
  ...
  headers: {
    "Forward-Email": "email"
  }
}
```

This will cause eas to set the header `X-Forward-Email` with the
value returned by `userinfo.data.email`.

Fixes #5