### PR TITLE
Run as non-root user in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+node_modules
+npm-debug.log
+Dockerfile
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,11 @@
 FROM node:10
 
-WORKDIR /app
+# Run as a non-root user
+RUN useradd --create-home eas \
+        && mkdir /home/eas/app \
+        && chown -R eas: /home/eas
+WORKDIR /home/eas/app
+USER eas
 
 COPY . .
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,10 @@ RUN useradd --create-home eas \
 WORKDIR /home/eas/app
 USER eas
 
-COPY . .
-
+COPY package*.json ./
 RUN npm install
+
+COPY --chown=eas:eas . .
 
 EXPOSE 8080
 


### PR DESCRIPTION
Since the service may be exposed to the internet, it's probably best not to run as root, even in the container.

While I was here I made the following improvements:

 - Copy `package*.json` separately and run `npm install` before copying the rest of the app. This should make builds quicker when trying to iterate locally since you won't need to reinstall all the dependencies if you didn't change the spec.
 - Added a `.dockerignore` to preclude copying in the local `node_modules` folder and other unnecessary files.

@travisghansen Do you have a preference for squashed PRs? I left it un-squashed but I'd be happy to do so if you prefer.