### PR TITLE
0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 # 0.4.0
 
+- helm repo analogy for server-side config tokens store IDs
+
 - explore client-side `config_token` encryption (ie: pki encryption of `config_tokens`)
 - look into support multiple `config_token` keys (ie: run external server as a service style setup)
 - look into 'proper' `config_token` jwt encryption
@@ -42,6 +44,15 @@
   - LinkedIn
 
 - required plugins (ie: support multi-success pipepline)
+
+# 0.3.1
+
+Released 2019-06-18
+
+- ~~better helm example incorportating `redis-ha`~~
+- ~~explicitly disable `nonce` checking for `oidc`~~
+- ~~better parent request URI reconstruction for traefik edge-cases (prefix replacement, regex alterations)~~
+- ~~better documentation around `oidc` and `oauth2` sessions~~
 
 # 0.3.0
 

--- a/OAUTH_PLUGINS.md
+++ b/OAUTH_PLUGINS.md
@@ -1,0 +1,64 @@
+# Intro
+
+By far the `oidc` and `oauth2` plugins are the most copmlex of `eas`. Several
+factors are involved in this but this also makes the configuration more
+intricate. This document is an effort to provide as much info as possible to
+provide more detail into the various parts.
+
+# Stateful
+
+A key thing to understand is that the `oidc` and `oauth2` plugins create a
+stateful session with `eas`. This is why redis is generally required if using
+either plugin as sessions are stored in redis.
+
+All of this is managed via a signed cookie which is stored by the user-agent
+(browser) for a configurable period of time (see `cookie_expiry` option). The
+various other cookie options are configurable as well
+(`name`, `domain`, `path`, etc) on a per-`config_token` basis. With careful
+configuration you can enable SSO scenarios amongst other options.
+
+Generally, `eas` ensures the presense of the appropriately named cookie and
+ensures it was signed by `eas`. This can however result in an insecure setup as
+several services secured by the same `eas` deployment all share the same cookie
+signing key. To overcome this threat, `eas` sessions are bound to a particular
+audience. You can configure this audience by setting the `aud` value in the/a
+`config_token` to a specific value. Any services sharing that same `aud` will
+consider sessions valid. If the `aud` value is omitted in the `config_token`
+then `eas` will generate a unique hash of the complete `config_token` data and
+use that as the `aud` value. This is a 'secure by default' approach but allows
+for powerful control by operators to meet their unique/individual needs.
+
+If you intend to secure several services with the same `config_token` using
+`oidc` or `oauth2` (SSO), then there are several recommendations:
+
+- explicitly set the `aud` value in the `config_token`
+- explicitly set the `redirect_uri` to point to
+  `https://eas.example.com/oauth/callback`
+- explicitly set the `cookie.domain` value to the generic domain `example.com`
+- carefully consider the `cookie.name` and `cookie.path` values as appropriate
+- ensure unique combinations of `aud`, `cookie.domain`, and `cookie.name` for
+  disperse services which should **NOT** share sessions
+
+As an example, consider a scenario with 2 different `config_token`s (perhaps
+different `oidc` providers or perhaps requiring different `assertions`) which
+will be used across 10 different services (5 each) each with the same TLD. The
+configuration outlined below will ensure each `config_token` is only used when
+appropriate and will ensure different services are not conflicting with each
+other for the session data. It also ensures the services are properly secured
+according to operator desires.
+
+The applicable `config_token` options would be:
+
+## token 1
+
+- `aud` set to `company-basic`
+- `cookie.domain` set to `example.com`
+- `cookie.name` set to `_oeas_oauth_session_basic`
+- `redirect_uri` set to `https://eas.example.com/oauth/callback`
+
+## token 2
+
+- `aud` set to `admins`
+- `cookie.domain` set to `example.com`
+- `cookie.name` set to `_oeas_oauth_session_admins`
+- `redirect_uri` set to `https://eas.example.com/oauth/callback`

--- a/PLUGINS.md
+++ b/PLUGINS.md
@@ -211,6 +211,8 @@ Initiates oauth `Authorization Code Flow` for authentication with any provider.
 Some providers only allow a single active token per-user per-client_id. This
 can be a limitation if the same user is using multiple browsers/sessions.
 
+Please read [further details](OAUTH_PLUGINS.md) about configuration.
+
 ```
 {
     type: "oauth2",
@@ -345,6 +347,8 @@ Initiates OpenID Connect `Authorization Code Flow` for authentication with any p
 
 Some providers only allow a single active token per-user per-client_id. This
 can be a limitation if the same user is using multiple browsers/sessions.
+
+Please read [further details](OAUTH_PLUGINS.md) about configuration.
 
 ```
 {

--- a/README.md
+++ b/README.md
@@ -45,7 +45,10 @@ indexed) parameter on the authentication URL.
 # Usage
 
 If running multiple instances (HA) you will need a shared cache/store (see
-redis below).
+redis below). You only **really** need redis if:
+
+1. You are running HA
+1. You are using the `oidc` or `oauth2` plugins
 
 Refer to the [HOWTO](HOWTO.md) for a more detailed overview.
 
@@ -109,12 +112,15 @@ travisghansen/external-auth-server
 
 ### Kubernetes
 
-A `helm` chart is supplied in the repo directly.
+A `helm` chart is supplied in the repo directly. Reviewing
+(values.yaml)[chart/values.yaml] is **highly** recommended as examples are
+provided for common use-cases.
 
 ```
 helm upgrade \
 --install \
---namespace=kube-system \
+--namespace=external-auth-server \
+\
 --set configTokenSignSecret=<random> \
 --set configTokenEncryptSecret=<random> \
 --set issuerSignSecret=<random> \
@@ -123,9 +129,22 @@ helm upgrade \
 --set cookieEncryptSecret=<random> \
 --set sessionEncryptSecret=<random> \
 --set logLevel="info" \
---set storeOpts.store="redis" \
---set storeOpts.host="redis.lan" \
---set storeOpts.prefix="eas:" \
+\
+--set redis-ha.enabled=true \
+--set redis-ha.auth=true \
+--set redis-ha.redisPassword=53c237 \
+\
+--set storeOpts.store=ioredis \
+--set storeOpts.password=53c237 \
+--set storeOpts.name=mymaster \
+--set storeOpts.sentinels[0].host=eas-redis-ha-announce-0 \
+--set storeOpts.sentinels[0].port=26379 \
+--set storeOpts.sentinels[1].host=eas-redis-ha-announce-1 \
+--set storeOpts.sentinels[1].port=26379 \
+--set storeOpts.sentinels[2].host=eas-redis-ha-announce-2 \
+--set storeOpts.sentinels[2].port=26379 \
+--set storeOpts.keyPrefix="eas:" \
+\
 --set ingress.enabled=true \
 --set ingress.hosts[0]=eas.example.com \
 --set ingress.paths[0]=/ \

--- a/src/plugin/oauth/index.js
+++ b/src/plugin/oauth/index.js
@@ -1459,6 +1459,7 @@ class OpenIdConnectPlugin extends BaseOauthPlugin {
       parentReqInfo.parsedQuery,
       {
         state: parentReqInfo.parsedQuery.state,
+        nonce: null,
         response_type
       }
     );


### PR DESCRIPTION
- minor tweaks to support traefik URL edge-cases
- ignore `nonce` checks (keycloak with google produces a token with nonce set during the initial auth phase)
- update helm example command incorporating `redis-ha`