### PR TITLE
Honor the cookie expiry setting for oauth

### DIFF
--- a/src/plugin/oauth/index.js
+++ b/src/plugin/oauth/index.js
@@ -375,7 +375,7 @@ class BaseOauthPlugin extends BasePlugin {
         plugin.config.features.cookie_expiry > 0
       ) {
         cookieExpiresAt =
-          Date.now() / 1000 + plugin.config.features.session_expiry;
+          Date.now() / 1000 + plugin.config.features.cookie_expiry;
         cookieExpiresAt = cookieExpiresAt * 1000;
       } else {
         cookieExpiresAt = tokenExpiresAt;


### PR DESCRIPTION
Currently if one sets the cookie_expiry value to a number then the
`session_expiry` will be used to set the `cookie expiry`. This can be
problem since if session_expiry is not a number then cookies will be set
to expire immediately. Therefore, if one wants to set the cookie expiry
today they must set both the `cookie_expiry` and `session_expiry`
together.

Side note: I ran into this while looking into issues I'm having with refresh
tokens. I think the actual refresh logic is correct but configuring the
correct session/cookie expiry seems to be problematic, which is how I
found this bug.