### PR TITLE
Reuse refesh_token if not provided an updated one

### DIFF
--- a/src/plugin/oauth/index.js
+++ b/src/plugin/oauth/index.js
@@ -563,7 +563,13 @@ class BaseOauthPlugin extends BasePlugin {
             );
             try {
               plugin.server.logger.verbose("refreshing tokenSet");
+              const originalTokenSet = tokenSet;
               tokenSet = await plugin.refresh_token(tokenSet);
+              // If the refreshed tokenset doesn't contain a new refresh token then assume the
+              // original one can still be used.
+              if (tokenSet.refresh_token === undefined) {
+                tokenSet.refresh_token = originalTokenSet.refresh_token;
+              }
               sessionPayload.tokenSet = tokenSet;
 
               let userinfo;


### PR DESCRIPTION
The spec seems to be a bit unclear here since the `refresh_token` is
optional in the repsonse. It seems to be open to interpretation whether
that means the original `refresh_token` is still valid. I think most
providers do allow reuse of `refresh_tokens` up until the expiry of that
token.

Should they not be reusable then that should just mean we fail to
refresh next time around and assertions should fail causing a 302.

See #44