### PR TITLE
Added SecurityContext for Helm Chart

### DIFF
--- a/charts/external-auth-server/templates/deployment.yaml
+++ b/charts/external-auth-server/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.securityContext.enabled }}
+          securityContext:
+            runAsUser: {{ .Values.securityContext.runAsUser }}
+          {{- end }}
           env:
             - name: NODE_ENV
               value: "production"
@@ -146,4 +150,8 @@ spec:
           items:
             - key: node-extra-ca-certs
               path: node-extra-ca-certs.crt
+      {{- if .Values.securityContext.enabled }}
+      securityContext:
+        fsGroup: {{ .Values.securityContext.fsGroup }}
+      {{- end }}
 

--- a/charts/external-auth-server/values.yaml
+++ b/charts/external-auth-server/values.yaml
@@ -128,3 +128,8 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+securityContext:
+  enabled: false
+  fsGroup: 1001
+  runAsUser: 1001


### PR DESCRIPTION
Kubernetes couldn't check usernames, even if you have it in Dockerfile like: `USER eas`, it understands only IDs.
For those who are using PodSecurityPolicies, or other Security restraints this setting may be helpful.
Disabled by default for keeping everything as it was before.