### PR TITLE
added support for running with generate-config-token from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,5 @@ RUN npm install
 COPY --chown=eas:eas . .
 
 EXPOSE 8080
-
-CMD [ "npm", "start" ]
+ENTRYPOINT [ "npm", "run", "--silent"]
+CMD [ "start" ]

--- a/bin/generate-config-token-stdin.js
+++ b/bin/generate-config-token-stdin.js
@@ -1,0 +1,22 @@
+const jwt = require("jsonwebtoken");
+const utils = require("../src/utils");
+const fs = require('fs');
+
+const config_token_sign_secret =
+  process.env.EAS_CONFIG_TOKEN_SIGN_SECRET ||
+  utils.exit_failure("missing EAS_CONFIG_TOKEN_SIGN_SECRET env variable");
+const config_token_encrypt_secret =
+  process.env.EAS_CONFIG_TOKEN_ENCRYPT_SECRET ||
+  utils.exit_failure("missing EAS_CONFIG_TOKEN_ENCRYPT_SECRET env variable");
+
+const data = fs.readFileSync(0, 'utf-8');
+  
+let config_token = JSON.parse(data)  
+
+config_token = jwt.sign(config_token, config_token_sign_secret);
+const config_token_encrypted = utils.encrypt(
+  config_token_encrypt_secret,
+  config_token
+);
+
+console.log(config_token_encrypted);

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "src/server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node --nouse-idle-notification --expose-gc --max-old-space-size=8192 src/server.js"
+    "start": "node --nouse-idle-notification --expose-gc --max-old-space-size=8192 src/server.js",
+    "generate-config-token": "node --nouse-idle-notification --expose-gc --max-old-space-size=8192 bin/generate-config-token-stdin.js"
   },
   "author": "Travis Glenn Hansen <travisghansen@yahoo.com>",
   "bugs": {


### PR DESCRIPTION
Using this PR you can do the following :

```
token=`cat << EOF | docker run -i -eEAS_CONFIG_TOKEN_SIGN_SECRET=xxx -eEAS_CONFIG_TOKEN_ENCRYPT_SECRET=yyy external-auth-server generate-config-token
{
  "eas": {
    "plugins": [
      {
        "type": "htpasswd",
        "realm": "Test",
        "htpasswd": "cameron:$2y$05$oJEsyl0K9ZMUMBn2NwYxTO1rWq2EqOPRimlk4073GlkoCMXtnZIXW"
      }      
    ]
  }
}
EOF`
echo $token
```
