### PR TITLE
add priorityClassName value in helm chart

### DIFF
--- a/charts/external-auth-server/Chart.yaml
+++ b/charts/external-auth-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: external-auth-server
-version: 0.1.1
+version: 0.1.2

--- a/charts/external-auth-server/templates/deployment.yaml
+++ b/charts/external-auth-server/templates/deployment.yaml
@@ -30,6 +30,9 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.priorityClassName }}
+          priorityClassName: {{ .Values.priorityClassName | quote }}
+          {{- end }}
           {{- if .Values.securityContext.enabled }}
           securityContext:
             runAsUser: {{ .Values.securityContext.runAsUser }}

--- a/charts/external-auth-server/values.yaml
+++ b/charts/external-auth-server/values.yaml
@@ -129,6 +129,10 @@ tolerations: []
 
 affinity: {}
 
+# Priority indicates the importance of a Pod relative to other Pods.
+# https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/
+priorityClassName: ""
+
 securityContext:
   enabled: false
   fsGroup: 1001


### PR DESCRIPTION
Adds priority class name configuration in helm chart to have possibility for pod prioritization over other noncritical pods.