### PR TITLE
Unpack knex response correctly when using pg client

### DIFF
--- a/src/config_token_store/adapter/sql/index.js
+++ b/src/config_token_store/adapter/sql/index.js
@@ -46,7 +46,16 @@ class SqlConfigTokenStoreAdapter extends BaseConfigTokenStoreAdapter {
 
     try {
       const resp = await client.raw(adapter.config.options.query, [id]);
-      const row = resp[0][0];
+      
+      let row;
+
+      switch (adapter.config.options.config.client) {
+        case "pg":
+          row = resp.rows[0]; break;
+        default:
+          row = resp[0][0];
+      }
+      
       return row.token;
     } catch (e) {
       throw e;


### PR DESCRIPTION
Under https://knexjs.org/#Raw we are told `Note that the response will be whatever the underlying sql library would typically return on a normal query, so you may need to look at the documentation for the base library the queries are executing against to determine how to handle the response.`.

My assumption is that the existing response handler in the eas SQL adapter only supports the mysql database library considering the documentation is oriented towards mysql.

My proposed change allows us to correctly unpack a pg database library response while keeping the existing approach for all other libraries. The above change may need to be extended for the sqlite3 and mssql libraires depending on their specific response objects.