### PR TITLE
Logging and misc improvements

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -188,7 +188,7 @@ function get_parent_request_uri(req) {
     originalRequestURI = originalRequestURI.replace(/^(.+?)\/*?$/, "$1"); // remove all trailing slashes
     originalRequestURI += req.headers["x-forwarded-uri"];
   } else {
-    originalRequestURI += req.headers["x-forwarded-uri"];
+    originalRequestURI += req.headers["x-forwarded-uri"] || '';
   }
 
   //x-forwarded-port


### PR DESCRIPTION
Hi, we've been playing around with this for a couple of days now and made some improvements you may want. They're mainly concerning logging to allow us to figure out what was happening on our end.

We found that if scope was only "openid offline_access" then of course no access_token is issued. While not a big problem `access_token = null` caused `access_token_assertions` to throw an error. I added a check and a log entry in order to handle it gracefully, then did the same for id_token in case someone don't have openid in the scope.

Lastly, like we discussed in #131 we got a domain `mydomain.comundefined` because `x-forwarded-uri` was assumed to have a value. So we added a fallback value as it's better to have no path than mess up the domain.