### PR TITLE
add image pull secrets to helm chart

### DIFF
--- a/charts/external-auth-server/Chart.yaml
+++ b/charts/external-auth-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: external-auth-server
-version: 0.2.0
+version: 0.2.1

--- a/charts/external-auth-server/templates/deployment.yaml
+++ b/charts/external-auth-server/templates/deployment.yaml
@@ -26,6 +26,10 @@ spec:
       {{- if .Values.priorityClassName }}
       priorityClassName: {{ .Values.priorityClassName | quote }}
       {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/external-auth-server/values.yaml
+++ b/charts/external-auth-server/values.yaml
@@ -69,6 +69,11 @@ image:
   tag: latest
   #pullPolicy: IfNotPresent
 
+# When it is not possible to access public container registry and it is required to be deployed from private
+# container registry. When kubernetes.io/dockerconfigjson secret is present it can be used to pull a private image.
+# Usage: -- set imagePullSecrets[0].name=private-container-credentials-secret-name
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
This will allow to specify imagePullSecrets for helm charts in case access to public container registry is not possible.

Thanks for awesome work!