### PR TITLE
Add EAS_ENCRYPT_IV_SECRET environment variable to helm template

### DIFF
--- a/charts/external-auth-server/templates/deployment.yaml
+++ b/charts/external-auth-server/templates/deployment.yaml
@@ -87,6 +87,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "external-auth-server.fullname" . }}
                   key: config-token-encrypt-secret
+            - name: EAS_ENCRYPT_IV_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "external-auth-server.fullname" . }}
+                  key: config-token-encrypt-iv-secret
             - name: EAS_ISSUER_SIGN_SECRET
               valueFrom:
                 secretKeyRef:

--- a/charts/external-auth-server/templates/secrets.yaml
+++ b/charts/external-auth-server/templates/secrets.yaml
@@ -8,11 +8,13 @@ type: Opaque
 data:
   config-token-sign-secret: {{ required "configTokenSignSecret is required" .Values.configTokenSignSecret | b64enc | quote }}
   config-token-encrypt-secret: {{ required "configTokenEncryptSecret is required" .Values.configTokenEncryptSecret | b64enc | quote }}
+  config-token-encrypt-iv-secret: {{ .Values.configTokenEncryptIVSecret | b64enc | quote }}
   issuer-sign-secret: {{ required "issuerSignSecret is required" .Values.issuerSignSecret | b64enc | quote }}
   issuer-encrypt-secret: {{ required "issuerEncryptSecret is required" .Values.issuerEncryptSecret | b64enc | quote }}
   cookie-sign-secret: {{ required "cookieSignSecret is required" .Values.cookieSignSecret | b64enc | quote }}
   cookie-encrypt-secret: {{ required "cookieEncryptSecret is required" .Values.cookieEncryptSecret | b64enc | quote }}
   session-encrypt-secret: {{ required "sessionEncryptSecret is required" .Values.sessionEncryptSecret | b64enc | quote }}
+
   {{- if .Values.storeOpts }}
   store-opts: {{ .Values.storeOpts | toJson | b64enc | quote }}
   {{- end }}

--- a/charts/external-auth-server/values.yaml
+++ b/charts/external-auth-server/values.yaml
@@ -4,6 +4,7 @@
 
 configTokenSignSecret:
 configTokenEncryptSecret:
+configTokenEncryptIVSecret:
 issuerSignSecret:
 issuerEncryptSecret:
 cookieSignSecret:


### PR DESCRIPTION
Add capability to optionally configure the EAS_ENCRYPT_IV_SECRET environment variable from helm template. 
If set, the IV secret will be used in encryption and decryption of the config token.