### PR TITLE
remove obsolete files from docker image for OWASP compliance

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,14 @@ RUN useradd --create-home eas \
 
 COPY --from=build --chown=eas:eas /tmp/app /home/eas/app
 
+# Remove obsolete files
+RUN rm -rf /home/eas/app/examples \
+        && rm -rf  /home/eas/app/.git* \
+        && rm -rf /home/eas/app/.travis* \
+        && rm -rf /home/eas/app/contrib \
+        && rm -rf /home/eas/app/charts \
+        && rm /home/eas/app/*.md
+
 WORKDIR /home/eas/app
 USER eas
 


### PR DESCRIPTION
Hey,

In order to be compliant with OWASP Application Security Verification Standard it is required to remove "unneeded configurations and folders such as sample applications, platform documentation, and default or example users"