### PR TITLE
Log exceptions instead of crashing

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -89,6 +89,14 @@ app.get("/ping", (req, res) => {
 });
 
 verifyHandler = async (req, res, options = {}) => {
+  try {
+    await _verifyHandler(req, res, options)
+  } catch (error) {
+    externalAuthServer.logger.error(error)
+  }
+}
+
+_verifyHandler = async (req, res, options = {}) => {
   externalAuthServer.logger.silly("verify request details: %j", {
     url: req.url,
     params: req.params,


### PR DESCRIPTION
For example: a call to `/verify` with a token without an `eas.plugins.connection` field makes external-auth-server crash.