### PR TITLE
feat: helm configurable probes

### DIFF
--- a/charts/external-auth-server/templates/deployment.yaml
+++ b/charts/external-auth-server/templates/deployment.yaml
@@ -142,13 +142,9 @@ spec:
 {{- end }}
 
           livenessProbe:
-            httpGet:
-              path: /ping
-              port: http
+            {{- toYaml .Values.livenessProbe | nindent 12 }}
           readinessProbe:
-            httpGet:
-              path: /ping
-              port: http
+            {{- toYaml .Values.readinessProbe | nindent 12 }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}

--- a/charts/external-auth-server/values.yaml
+++ b/charts/external-auth-server/values.yaml
@@ -138,6 +138,16 @@ redis-ha:
 #  - host: eas-redis-ha-announce-2
 #    port: 26379
 
+livenessProbe:
+  httpGet:
+    path: /ping
+    port: http
+
+readinessProbe:
+  httpGet:
+    path: /ping
+    port: http
+
 resources:
   {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
Adds configurable probes to the helm chart. We've noticed that in certain cases the pods can even start crashlooping because the default configuration can be a bit barebones.

I kept the current default values for those, but feel free to disagree on that.